### PR TITLE
Support LaTeX comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -337,37 +337,37 @@ func getFiles(filePath string) []string {
 func initMatchers() []matcher {
 	return []matcher{
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*NOTE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*NOTE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ✐ NOTE`,
 			Tag:   "NOTE",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*OPTIMIZE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*OPTIMIZE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ↻ OPTIMIZE`,
 			Tag:   "OPTIMIZE",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*TODO\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*TODO\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ✓ TODO`,
 			Tag:   "TODO",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*HACK\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*HACK\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ✄ HACK`,
 			Tag:   "HACK",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*XXX\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*XXX\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ✗ XXX`,
 			Tag:   "XXX",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*FIXME\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*FIXME\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: ` ☠ FIXME`,
 			Tag:   "FIXME",
 		},
 		{
-			Regex: `(?i)(?:[\/\/][\/\*]|#)\s*BUG\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
+			Regex: `(?i)(?:[\/\/][\/\*]|#|%)\s*BUG\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)`,
 			Label: `☢ BUG`,
 			Tag:   "BUG",
 		},


### PR DESCRIPTION
Hey, thanks for this cool and simple tool.

I noticed that it didn't support comment lines that start with a percentage sign, such as the ones in [LaTeX](https://en.wikipedia.org/wiki/LaTeX).

So I edited the regex to also include it, and in my tests it seems to work correctly.

It now also marks lines that look like this, and all other starting keywords:
```
% TODO: this needs to be changed
```

If you have any ideas on how this could interfere with other file types please let me know.